### PR TITLE
Added link to plugin certification program in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Before attempting to create a plugin, please assess your personal ability. Plugi
 ### Reference
 
 * [NetBox Plugin Development Documentation](https://netbox.readthedocs.io/en/stable/plugins/development/)
+* [NetBox Labs Certified Plugin Program](https://github.com/netbox-community/netbox/wiki/Plugin-Certification-Program)
 
 ### Getting Help
 


### PR DESCRIPTION
Dropped a link to the plugin certification program details on the NetBox project wiki.