### PR TITLE
Update import statement for netbox 4.0+

### DIFF
--- a/tutorial/step01-initial-setup.md
+++ b/tutorial/step01-initial-setup.md
@@ -44,7 +44,7 @@ $ touch netbox_access_lists/__init__.py
 Next, open `__init__.py` in the text editor of your choice and import the `PluginConfig` class from NetBox at the top of the file.
 
 ```python
-from extras.plugins import PluginConfig
+from netbox.plugins import PluginConfig
 ```
 
 ### Create the PluginConfig Class


### PR DESCRIPTION
In netbox 4.0 the line needed to import PluginConfig has change:

old:
`from extras.plugins import PluginConfig`

new:
`from netbox.plugins import PluginConfig`